### PR TITLE
[Refactor] Redefine `Direction` and `Action` as enums

### DIFF
--- a/hypatia/constants.py
+++ b/hypatia/constants.py
@@ -27,39 +27,18 @@ __email__ = "lillian.lynn.lemmer@gmail.com"
 __status__ = "Development"
 
 
-class Direction(object):
+
+from enum import Enum
+
+
+
+class Direction(Enum):
     """Specific to movement of a sprite/surface."""
-    pass
+    Up = 1
+    Down = 2
+    Left = 3
+    Right = 4
 
-
-class Up(Direction):
-    """Move in direction: up"""
-    pass
-
-
-class Right(Direction):
-    """Move in direction: right"""
-    pass
-
-
-class Down(Direction):
-    """Move in direction: down"""
-    pass
-
-
-class Left(Direction):
-    """Move in direction: left"""
-    pass
-
-
-class Action(object):
-    pass
-
-
-class Walk(Action):
-    pass
-
-
-class Stand(Action):
-    pass
-
+class Action(Enum):
+    Walk = 1
+    Stand = 2

--- a/hypatia/game.py
+++ b/hypatia/game.py
@@ -76,7 +76,7 @@ class Game(object):
         for event in pygame.event.get():
 
             if event.type == KEYUP:
-                self.scene.human_player.walkabout.action = constants.Stand
+                self.scene.human_player.walkabout.action = constants.Action.Stand
             
             # need to trap player in a next loop, release when no next
             if event.type == KEYDOWN and event.key == K_SPACE:
@@ -98,16 +98,16 @@ class Game(object):
             return False
 
         if pressed_keys[K_UP]:
-            self.move_player(constants.Up)
+            self.move_player(constants.Direction.Up)
 
         if pressed_keys[K_RIGHT]:
-            self.move_player(constants.Right)
+            self.move_player(constants.Direction.Right)
 
         if pressed_keys[K_DOWN]:
-            self.move_player(constants.Down)
+            self.move_player(constants.Direction.Down)
 
         if pressed_keys[K_LEFT]:
-            self.move_player(constants.Left)
+            self.move_player(constants.Direction.Left)
 
         return True
 
@@ -122,7 +122,7 @@ class Game(object):
           Needs to use velocity instead...
 
         Args:
-          direction (constants.Direction): may be one of: up, right, down, left
+          direction (constants.Direction): may be one of: Up, Right, Down, Left
 
         """
 
@@ -142,13 +142,13 @@ class Game(object):
             if pixels == 2:
                 adj_speed = 1
 
-            if direction == constants.Up:
+            if direction == constants.Direction.Up:
                 new_topleft_y -= pixels * adj_speed
-            elif direction == constants.Right:
+            elif direction == constants.Direction.Right:
                 new_topleft_x += pixels * adj_speed
-            elif direction == constants.Down:
+            elif direction == constants.Direction.Down:
                 new_topleft_y += pixels * adj_speed
-            elif direction == constants.Left:
+            elif direction == constants.Direction.Left:
                 new_topleft_x -= pixels * adj_speed
 
             destination_rect = pygame.Rect((new_topleft_x, new_topleft_y),
@@ -158,7 +158,7 @@ class Game(object):
             if not self.collide_check(collision_rect):
                 # we're done, we can move!
                 new_topleft = (new_topleft_x, new_topleft_y)
-                player.walkabout.action = constants.Walk
+                player.walkabout.action = constants.Action.Walk
                 animation = player.walkabout.current_animation()
                 player.walkabout.size = animation.getMaxSize()
                 player.walkabout.rect = destination_rect
@@ -167,7 +167,7 @@ class Game(object):
                 return True
 
         # never found an applicable destination
-        player.walkabout.action = constants.Stand
+        player.walkabout.action = constants.Action.Stand
 
         return False
 

--- a/hypatia/player.py
+++ b/hypatia/player.py
@@ -24,13 +24,13 @@ class Player(object):
         # to talk to npc if collide
         facing = self.walkabout.direction
         
-        if facing is constants.Up:
+        if facing is constants.Direction.Up:
             disposition = (0, -1)
-        elif facing is constants.Right:
+        elif facing is constants.Direction.Right:
             disposition = (1, 0)
-        elif facing is constants.Down:
+        elif facing is constants.Direction.Down:
             disposition = (0, 1)
-        elif facing is constants.Left:
+        elif facing is constants.Direction.Left:
             disposition = (-1, 0)
 
         talk_rect = self.walkabout.rect.copy()
@@ -51,10 +51,10 @@ class Npc(Player):
 
     def say(self, at_direction, dialogbox):
         facing = {
-                  constants.Up: constants.Down,
-                  constants.Right: constants.Left,
-                  constants.Left: constants.Right,
-                  constants.Down: constants.Up
+                  constants.Direction.Up: constants.Direction.Down,
+                  constants.Direction.Right: constants.Direction.Left,
+                  constants.Direction.Left: constants.Direction.Right,
+                  constants.Direction.Down: constants.Direction.Up
                  }[at_direction]
         self.walkabout.direction = facing
         

--- a/hypatia/sprites.py
+++ b/hypatia/sprites.py
@@ -278,8 +278,8 @@ class Walkabout(object):
             file_name = os.path.split(file_name)[1]
 
             if file_name == 'only':
-                action = constants.Stand
-                direction = constants.Down
+                action = constants.Action.Stand
+                direction = constants.Direction.Down
 
             else:
                 action, direction = file_name.split('_', 1)
@@ -315,8 +315,8 @@ class Walkabout(object):
         self.size = animation.getMaxSize()
         self.rect = pygame.Rect(position, self.size)
         self.topleft_float = topleft_float
-        self.action = constants.Stand
-        self.direction = constants.Down
+        self.action = constants.Action.Stand
+        self.direction = constants.Direction.Down
         self.speed_in_pixels_per_second = 20.0
         self.child_walkabouts = children or []
 
@@ -332,7 +332,7 @@ class Walkabout(object):
 
         Examples:
           >>> walkabout = Walkabout()
-          >>> walkabout[constants.Walk][constants.Up]
+          >>> walkabout[constants.Action.Walk][constants.Direction.Up]
           <PygAnim Object>
 
         """
@@ -467,13 +467,13 @@ class Walkabout(object):
         """
 
         if len(self.animations) == 1:
-            actions = (constants.Stand,)
-            directions = (constants.Down,)
+            actions = (constants.Action.Stand,)
+            directions = (constants.Direction.Down,)
 
         else:
-            actions = (constants.Walk, constants.Stand)
-            directions = (constants.Up, constants.Down,
-                          constants.Left, constants.Right)
+            actions = (constants.Action.Walk, constants.Action.Stand)
+            directions = (constants.Direction.Up, constants.Direction.Down,
+                          constants.Direction.Left, constants.Direction.Right)
 
         for action in actions:
 


### PR DESCRIPTION
This patch refactors the `hypatia/constants.py` file.  The purpose of
the file/module is to define constants Hypatia uses for representing
directions an actor may face or move, and actions they may perform,
such as standing or walking.  However, despite the module's name, the
"constants" are not actually constant.  It is possible for errant code
to create a bug with something like:

    constants.Up = "Broken"

Admittedly this is a far-fetched and unlikely bug; such a line of code
would not be written directly.  But indirect redefinitions of the
constants are a possibility.

This patch eliminates the potential for this bug by redefining
directions and actions in terms of the `Enum` class.  It removes the
sub-classes of `Direction` and `Action` since those classes are now
represented as enumerated members of their parents.  This means we
must change every use of `constants` throughout the code-base, which
this patch does, but it makes it impossible for code like

    constants.Direction.Up = "Broken"

to run without raising an error.  The new constants have arbitrary
integer values but they are not derived from `IntEnum` because we have
no reason to ever compare them to actual integers, i.e. there is no
scenario where we would want to write such conditions as

    if constants.Action.Walk == 1: ...

The `Enum` class was introduced by Python 3.4, so in order for Hypatia
to remain compatible with Python 2.7 it is necessary to install the
`enum34` package, linked below, for systems not using Python 3.

Signed-off-by: Eric James Michael Ritz <ejmr@plutono.com>

Resolves: #26

See-Also: https://docs.python.org/3/library/enum.html
See-Also: https://pypi.python.org/pypi/enum34