### PR TITLE
[Feature] Improve the installation script for Ubuntu

### DIFF
--- a/install-ubuntu-py27.sh
+++ b/install-ubuntu-py27.sh
@@ -1,13 +1,14 @@
+#!/bin/sh
+#
 # Hypatia installation script for Ubuntu.
 #
-# Not tested. This doesn't force Python 2.7, I don't think?
+# Installs the following:
 #
-# Performs the following tasks:
-#   1. Installs the Ubuntu packages python-pygame and python-pip.
-#   2. Installs Python package requirements through PIP as normal user.
-#   3. Installs the Hypatia package as normal user.
+#   1. Python 2.7
+#   2. Packages python-pygame and python-pip.
+#   3. Required packages through pip as the normal user.
 
-
+sudo apt-get install python2.7 python2.7-dev python2.7-doc python2.7-dbg
 sudo apt-get install python-pygame python-pip
 pip install --user -r requirements.txt .
 


### PR DESCRIPTION
The current version of the script assumes the developer has already
installed Python.  This is a reasonable assumption but considering the
script's name it clearly intends to use Python 2.7, which the user may
not have if he is using only Python 3 or later.  It is not a guarantee
that Python 2.7 will always be available on a fresh install of Ubuntu.

This patch addresses that issue by modifying the script to install the
following packages from Ubuntu's standard package repository:

1. python2.7
2. python2.7-dev
3. python2.7-dbg
4. python2.7-doc

Only the first is absolutely necessary.  The other three are
convenient additions for developers, providing development libraries,
debugging tools, and a local copy of Python 2.7's documentation.

Developers on Ubuntu who are using Python 3 will be unaffected since
(at this time of writing) Python 3 is installed as

    /usr/bin/python3

and related programs, like the Python 3 version of pip, have similar
installation paths.

This patch also adds `#!/bin/sh` to the start of the script to ensure
that shell is used for the commands.  Right now the script does not
use any constructs which would cause problems for alternative shells
like zsh or Fish, but this addition is a safeguard for future changes
which may use constructs specific to the standard POSIX shell.

Finally, this commit makes the script executable by the user so that
they can run

    ./install-ubuntu-py27.sh

instead of having to run

    sh ./install-ubuntu-py27.sh

This small convenience is aided by the addition of `#!/bin/sh` so that
there is no ambiguity about which shell to use.

Signed-off-by: Eric James Michael Ritz <ejmr@plutono.com>