### PR TITLE
[Refactor] Make all installation shell scripts executable

### DIFF
--- a/install-freebsd-py27.sh
+++ b/install-freebsd-py27.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 # Hypatia installation script for FreeBSD.
 #
 # Tested on FreeBSD 10.1-RELEASE-p10. ZSH.

--- a/install-linuxmint-34.sh
+++ b/install-linuxmint-34.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 # Hypatia installation script for Linuxmint and Python 3.4.
 #
 # Forgot which version this was tested in.

--- a/install-linuxmint-py27.sh
+++ b/install-linuxmint-py27.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 # Hypatia installation script for Linuxmint.
 #
 # Forgot which version this was tested in.


### PR DESCRIPTION
Like dd923462 this patch makes two changes to all of the installation
shell scripts:

1. It makes them executable via `chmod u+x`.

2. It adds `#!/bin/sh` as the first line.

These changes make it possible to for developers to execute the
scripts simply by running, for example

    $ ./install-linuxmint-34.sh

The second change in particular makes the scripts slightly more
portable as there is an admittedly small chance that developers will
not be using a shell that is compatible with `/bin/sh` by default.
Adding that initial line to the top of each script protects the
scripts from breaking if a developer prefers to use some other
shell on their terminal.

Making each script executable removes the need to explicitly use `sh`
to run them.  The project wiki needs to be updated to reflect these
changes since it has examples like

    $ chmod +x install-linuxmint-34.sh
    $ sh ./install-linuxmint-34.sh

which can now be replaced with the single-line example above.

Signed-off-by: Eric James Michael Ritz <ejmr@plutono.com>

GitHub-Issue: #11
See-Also: dd9234629d9079c18631be2a54f5b0d881d65195