### PR TITLE
[Test] Add a shell script to install `py.test`

### DIFF
--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -10,9 +10,15 @@ PIP=${PIP:=$(which pip)}
 
 "$PIP" install pytest
 
+# Depending on which version of `pip` we used above we may have one of
+# two possible names for `py.test`.  So here we check for them and set
+# the most appropriate one.
+PYTEST=$(which py.test)
+PYTEST=${PYTEST:=$(which py.test-2.7)}
+
 # Run `py.test --version`, creating no output.  All we are looking for
 # is a successful exit code to indicate that the installation worked.
-py.test --version 1>/dev/null 2>&1
+"$PYTEST" --version 1>/dev/null 2>&1
 
 if [ "$?" != "0" ]; then
     echo "Error: Could not install and/or run py.test";

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+#
+# This script installs the tools developers need for testing Hypatia.
+# Developers must have either `pip` or `pip3` installed.  If both are
+# installed then `pip3` is given preference under the assumption that
+# the developer prefers to use Python 3.
+
+PIP=$(which pip3)
+PIP=${PIP:=$(which pip)}
+
+"$PIP" install pytest
+
+# Run `py.test --version`, creating no output.  All we are looking for
+# is a successful exit code to indicate that the installation worked.
+py.test --version 1>/dev/null 2>&1
+
+if [ "$?" != "0" ]; then
+    echo "Error: Could not install and/or run py.test";
+    exit 1;
+fi

--- a/tests/test_tiles.py
+++ b/tests/test_tiles.py
@@ -17,8 +17,6 @@ Example:
 """
 
 import os
-import zipfile
-from io import BytesIO
 
 import pygame
 import pytest


### PR DESCRIPTION
This patch adds a shell script to the `tests/` directory which will
install `py.test` on the developer's system, since that is the tool
used for Hypatia's test suite.  The rationale for putting this into a
separate script and not the existing installation scripts is that
pytest is *not* required for running Hypatia, only for developing it.
Therefore we do not want to install unnecessary dependencies for users
who are installing Hypatia with no intention of doing any serious
amount of development.

The installation script tries to install the Python 3 version of
pytest by testing for the existence of `pip3`.  The justification here
is that if `pip3` exists then it is very likely the developer prefers
to work on Hypatia using Python 3.  The script will fallback to the
Python 2.7 version of `pip` if `pip3` is not available.

The script relies on the use of redirecting output to `/dev/null` as
part of testing whether or not pytest installed successfully, which is
an aspect of the script that may break on Windows systems.  I do not
remember off the top of my head if Windows ports of shells like GNU
Bash handle `/dev/null` appropriately for that operating system.

Signed-off-by: Eric James Michael Ritz <ejmr@plutono.com>

GitHub-Issue: #42
See-Also: http://pytest.org/latest/