### PR TITLE
[Style] Make the docstrings for `Actor` conform to project guidelines

### DIFF
--- a/hypatia/actor.py
+++ b/hypatia/actor.py
@@ -5,7 +5,7 @@
 
 Actors are the base of any entities which may perform actions.
 Examples of actors are enemies, NPCs, the player herself, etc.  This
-module implements a basic Actor class to serve as the parent for any
+module implements a basic ``Actor`` class to serve as the parent for any
 classes representing objects such as those examples.  Any logic which
 can be shared by all such objects belongs in the class, for example
 the logic for moving around the game world.  This approach makes it
@@ -14,8 +14,8 @@ the same behavior, and this can be useful by making it easier (from a
 programming point-of-view) to give monsters the same set of core
 abilities and logic as NPCs, etc.
 
-When type-checking is necessary the Actor class provides a useful way
-to test for objects which support a bare-minimum of core, shared
+When type-checking is necessary the ``Actor`` class provides a useful
+way to test for objects which support a bare-minimum of core, shared
 actions.  The class is also useful in role-playing games for storing
 data that tends to be common between the Player, NPCs, enemies, et
 alia, a common example being statistics like hit-points.
@@ -26,45 +26,51 @@ from hypatia import animations
 from hypatia import constants
 
 
+
 class Actor(object):
     """The base class for any entity which can perform actions.
 
-    For example, both Player and NPC objects can move around the game
-    world.  This is the type of action which is shared by all 'actors'
-    and therefore best implemented in this class, allowing it to be
-    shared by as many entities as possible, e.g. enemies.
+    For example, both ``Player`` and ``NPC`` objects can move around
+    the game world.  This is the type of action which is shared by all
+    "actors" and therefore best implemented in this class, allowing it
+    to be shared by as many entities as possible, e.g. enemies.
 
-    It is typically not useful to directly instantiate Actor objects
-    but the implementation does not prevent this.
+    It is typically not useful to directly instantiate ``Actor``
+    objects but the implementation does not prevent this.
 
-    Public Properties:
+    Attributes:
 
-    walkabout -- An instance of animations.Walkabout()
-
-    direction -- An insance of constants.Direction() which indicates
-    the direction the actor is facing.  Is it possible to set this
-    property but doing so will raise an AttributeError if the new
-    value is not a valid object of the constants.Direction() class.
-    Trying to delete this property raises a TypeError.
+        walkabout: An instance of ``animations.Walkabout``.
 
     """
 
     def __init__(self, walkabout=None):
         """Constructs a new Actor.
 
-        Keyword arguments:
+        Arguments:
 
-        walkabout -- An instance of animations.Walkabout(), which is then
-        accessible via the 'walkabout' property.  This argument is
-        optional and defaults to new instance of animations.Walkabout().
+            walkabout: An instance of ``animations.Walkabout``, which
+                is then accessible via the ``walkabout`` property.
+                This argument is optional and defaults to new instance
+                of ``animations.Walkabout``.
 
         """
-
         self.walkabout = walkabout or animations.Walkabout()
 
         @property
         def direction(self):
+            """An intsance of ``constants.Direction``
 
+            This property indicates the direction the actor is facing.
+            Is it possible to set this property to a new value.
+
+            Raises:
+                AttributeError: If the new value is not a valid object
+                    of the ``constants.Direction`` class.
+
+                TypeError: If one tries to delete this property
+
+            """
             return self.walkabout.direction
 
         @direction.setter
@@ -72,8 +78,7 @@ class Actor(object):
 
             if not isinstance(new_direction, constants.Direction):
 
-                raise AttributeError(("Direction must be a valid "
-                                      "constants.Direction value"))
+                raise AttributeError(("Direction must be a valid constants.Direction value"))
 
             else:
                 self.walkabout.direction = new_direction


### PR DESCRIPTION
This patch contains no changes in the behavior of the `Actor` class.
All it does is modify the doctstrings to conform with the project
guidelines.

Signed-off-by: Eric James Michael Ritz <ejmr@plutono.com>

GitHub-Issue: #35
GitHub-Issue: #44
See-Also: https://github.com/lillian-lemmer/hypatia/wiki/Project-Guidelines