### PR TITLE
[Fix] Do not let `Direction` enums share values

### DIFF
--- a/hypatia/constants.py
+++ b/hypatia/constants.py
@@ -18,9 +18,11 @@ Examples:
 import enum
 
 
-# intentionally not using intenum
+# Intentionally not using `enum.IntEnum` because there is no reason to
+# compare values of `Direction` to integers.
+@enum.unique
 class Direction(enum.Enum):
-    """Compass direction. Specific to movement of a sprite/surfac.
+    """Compass direction. Specific to movement of a sprite/surface.
 
     Inspired by Unix numerical permissions. Only ever combined with
     one other direction max.
@@ -29,26 +31,35 @@ class Direction(enum.Enum):
         :class:`physics.Velocity`
 
     Note:
-        I don't  see a point in having a separate class for ordinal
+        I don't see a point in having a separate class for ordinal
         and cardinal classes.
 
     """
 
-    # Cardinal directions
+    # Cardinal Directions
+    #
+    # The values for these directions are the powers of two because
+    # that avoids potential conflicts with ordinal directions.  The
+    # values for ordinal directions are the addition of their cardinal
+    # components, e.g. `north_east` has the value of `north` plus
+    # `east`.  Defining the cardinal directions as powers of two
+    # avoids a problem by which ordinal directions could end up with
+    # same values which would make equality comparisons true for
+    # directions which should never be equal.
     north = 1
     east = 2
     south = 4
-    west = 6
+    west = 8
 
-    # Ordinal directions
+    # Ordinal Directions
     north_east = 3
-    noth_west = 7
+    north_west = 9
     south_east = 6
-    south_west = 10
+    south_west = 12
 
     # just for fun
     north_south = 5
-    east_west = 8
+    east_west = 10
 
     def __add__(cls, other_direction):
         """Combine one cardinal direction with another to get
@@ -60,12 +71,14 @@ class Direction(enum.Enum):
         Returns:
             :class:`Direction`: an ordinal direction.
 
+        >>> Direction.east + Direction.north == Direction.north_east
+        True
         """
 
-        # does this work
         return Direction(cls.value + other_direction.value)
 
 
+@enum.unique
 class Action(enum.Enum):
     """Specific to movement of a sprite/surface.
 


### PR DESCRIPTION
This patch redefines the cardinal directions in the `Direction` enum
to use values based on powers of two.  Most notably we change the
value of `Direction.west` from six to eight.  This change is because
of the following condition:

    Direction.west == Direction.south_east

This condition is true when `Direction.west` is equal to six.
Redefining the cardinal directions as powers of two avoids any
potential problems by which members of `Direction` share the same
values.  We define the addition operator for `Direction` which makes
this change useful for another reason, because now the values for all
ordinal directions correctly equal the addition of their cardinal
components, e.g. this is now true:

    Direction.east + Direction.north == Direction.north_east

The definition for `Direction.__add__()` now has a doctest
demonstrating this property.

To safeguard against similar problems in the future we wrap the
definitions of both enum classes, i.e. `Direction` and `Action`, with
the `enum.unique` decorator, which will raise an error if we ever try
to define properties of the enums that have the same values.

Finally this patch corrects a few random typos.

Signed-off-by: Eric James Michael Ritz <ejmr@plutono.com>

See-Also: https://docs.python.org/3/library/enum.html?#ensuring-unique-enumeration-values