### PR TITLE
Add NetBSD support using pkg_add/binary packages.

### DIFF
--- a/install-netbsd-python2.sh
+++ b/install-netbsd-python2.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Hypatia installation script for NetBSD.
+#
+# Tested on NetBSD 7.0_RC1. SH.
+
+# Ensure PKG_PATH is set prior to running this script (of the form PKG_PATH=ftp://ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/$arch/$release-number/All/)
+# $arch can be obtained with uname -m. $release-number in practice can vary but should match the major NetBSD version.
+
+su root -c 'pkg_add python27 py27-pip py27-game'
+./install-base-python2.sh
+


### PR DESCRIPTION
Self-explanatory. The process is a bit more involved compared to FreeBSD (set PKG_PATH environment variable; favor su over sudo, which is not provided by default on NetBSD), but nonetheless it works fine.

A number of python packages are available in pkgsrc (thin wrapper around pip **that may also add platform-specific patches to the source code**). I would like to package hypatia for pkgsrc when it reaches a more mature state. 

This would require favoring pkgsrc versions of python packages described in ./install-base-python.sh, instead of using pip directly (including Pillow and enum, at this time- Pyganim doesn't seem to have a pkgsrc package, so I'd need to add it as well). In addition to patching, Python pkgsrc pakages register themselves with an additional database on the filesystem is skipped when using pip alone.

However, since all invocations of pip in your install scripts use the --user flag, this should be a perfectly acceptable alternative that leaves the pkgsrc database none the wiser :).